### PR TITLE
 feat: Fix JS demo page to remove "aud"

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -5,3 +5,4 @@ and verify VAPID headers.
 
 The index.html file contains a stand-alone generator/verifier.
 
+[live demo](https://web-push-libs.github.io/vapid/js/)

--- a/js/index.html
+++ b/js/index.html
@@ -53,11 +53,6 @@
     <a name="claims"><h2>Claims</h2></a>
     <p>Claims are the information a site uses to identify itself.
     <div class="row">
-        <label for="aud" title="The full URL to your site."><b>Aud</b>ience:</label>
-        <p>The optional full URL to your site.</p>
-        <input name="aud" placeholder="https://push.example.com">
-    </div>
-    <div class="row">
     <label for="sub" ><b>Sub</b>scriber:</label>
     <p>The required administrative email address that can be contacted if there's an issue</p>
     <input name="sub" placeholder="mailto:admin@push.example.com">
@@ -67,6 +62,17 @@
     <p>Time in seconds for this claim to live. (Default/Max: 24 hours from now)</p>
     <input name="exp" id="vapid_exp" placeholder="Time in seconds">
     </div>
+    <p>&nbsp;</p>
+    <p><b><i>Note</i></b>: You can add more claims if you wish.
+    These can include things
+    like, the ID of the originating server (if you have several that may be
+    publishing updates), a proxied customer ID or hash (for privacy reasons,
+    you probably don't want to make this easily determinable), or any other
+    value that may be useful between the Push Server Ops team and yours.
+    Just make the values short so you don't run the risk of the server
+    rejecting a request because the headers are too big.</p>
+    <p>For example:
+    <code>{'ami_id':'e-1248296','cust_id':'a9afd519s919faio3'}</code></p>
     <div class="control">
     <button id="gen">Generate VAPID</button>
     </div>
@@ -124,7 +130,7 @@ function error(ex=null, msg=null, clear=false) {
 }
 
 function success(claims) {
-    for (let n of ["aud", "sub", "exp"]) {
+    for (let n of ["sub", "exp"]) {
         let item = document.getElementsByName(n)[0];
         item.value = claims[n];
         item.classList.add("updated");
@@ -171,15 +177,6 @@ function fetchClaims(){
         reply[item.name] = item.value;
     }
 
-    // verify aud
-    if (! /^https?:\/\//.test(reply['aud'])) {
-        error(null,
-            `Invalid Audience: Use the full URL of your site e.g. "http://example.com"`);
-        document.getElementsByName("aud")[0].classList.add("err");
-        err = true;
-    } else {
-        document.getElementsByName("aud")[0].classList.remove("err");
-    }
     // verify sub
     if (! /^mailto:.+@.+/.test(reply['sub'])) {
         error(null,
@@ -227,7 +224,9 @@ function gen(){
      }
      try {
          let rclaims = document.getElementById("raw_claims");
-         rclaims.innerHTML = JSON.stringify(claims, null, "    ");
+         let sc = JSON.stringify(claims, null, 4);
+         console.debug(sc);
+         rclaims.innerHTML = sc;
          rclaims.classList.add("updated");
          vapid.generate_keys().then(x => {
              vapid.sign(claims)

--- a/python/claims.json
+++ b/python/claims.json
@@ -1,4 +1,3 @@
 {
-    "aud": "https://catfacts.example.com",
     "sub": "mailto:webpush_ops@catfacts.example.com"
 }

--- a/python/py_vapid/__init__.py
+++ b/python/py_vapid/__init__.py
@@ -10,7 +10,7 @@ import ecdsa
 import logging
 from jose import jws
 
-__version__ = "0.2"
+__version__ = "0.3"
 
 
 class VapidException(Exception):

--- a/python/py_vapid/main.py
+++ b/python/py_vapid/main.py
@@ -49,15 +49,20 @@ The claims file should be a JSON formatted file that holds the
 information that describes you. There are three elements in the claims
 file you'll need:
 
-    "aud" This is your site's URL (e.g. "https://example.com")
     "sub" This is your site's admin email address
           (e.g. "mailto:admin@example.com")
     "exp" This is the expiration time for the claim in seconds. If you don't
           have one, I'll add one that expires in 24 hours.
 
+You're also welcome to add additional fields to the claims which could be
+helpful for the Push Service operations team to pass along to your operations
+team (e.g. "ami-id": "e-123456", "cust-id": "a3sfa10987"). Remember to keep
+these values short to prevent some servers from rejecting the transaction due
+to overly large headers. See https://jwt.io/introduction/ for details.
+
 For example, a claims.json file could contain:
 
-{"aud": "https://example.com", "sub": "mailto:admin@example.com"}
+{"sub": "mailto:admin@example.com"}
 """
             exit
         try:
@@ -65,6 +70,7 @@ For example, a claims.json file could contain:
             result = vapid.sign(claims)
         except Exception, exc:
             print "Crap, something went wrong: %s", repr(exc)
+            raise exc
 
         print "Include the following headers in your request:\n"
         for key, value in result.items():


### PR DESCRIPTION
"aud" was misidentified as a requirement, and to point to the wrong
host. Added text to various usage calls to indicate that you can use
your own tags and values, and why you might want to do that.

Also added link to "demo" page for the vapid JS form.

Closes #17