### PR TITLE
Convert JWT signatures to the correct format

### DIFF
--- a/python/py_vapid/utils.py
+++ b/python/py_vapid/utils.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 
 
 def b64urldecode(data):
@@ -23,3 +24,16 @@ def b64urlencode(data):
 
     """
     return base64.urlsafe_b64encode(data).replace(b'=', b'').decode('utf8')
+
+
+def num_to_bytes(n):
+    """Returns the byte representation of an integer, in big-endian order.
+
+    :param n: The integer to encode.
+    :type n: int
+
+    :returns bytes
+
+    """
+    h = '%x' % n
+    return binascii.unhexlify('0' * (len(h) % 2) + h)


### PR DESCRIPTION
`key.sign` returns a DER-encoded ASN.1 signature, but RFC 7518, section 3.4 says we should include R and S directly, in that order, and in big-endian form.

I also removed the test, because the alternative form of including the DER signature isn't standard, and likely to be rejected by other JWT implementations.