### PR TITLE
Fix python readme generate command argument

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -64,7 +64,7 @@ bin/python setup.py install
 Run by itself, `bin/vapid` will check and optionally create the
 public_key.pem and private_key.pem files.
 
-`bin/vapid -gen` can be used to generate a new set of public and
+`bin/vapid --gen` can be used to generate a new set of public and
 private key PEM files. These will overwrite the contents of
 `private_key.pem` and `public_key.pem`.
 

--- a/python/README.rst
+++ b/python/README.rst
@@ -71,7 +71,7 @@ App Usage
 Run by itself, ``bin/vapid`` will check and optionally create the
 public\_key.pem and private\_key.pem files.
 
-``bin/vapid -gen`` can be used to generate a new set of public and
+``bin/vapid --gen`` can be used to generate a new set of public and
 private key PEM files. These will overwrite the contents of
 ``private_key.pem`` and ``public_key.pem``.
 


### PR DESCRIPTION
Python readme has this command:
`bin/vapid -gen`
but it should be
`bin/vapid --gen`
instead.