### PR TITLE
Remove vestigal ecdsa library references

### DIFF
--- a/python/py_vapid/__init__.py
+++ b/python/py_vapid/__init__.py
@@ -41,7 +41,7 @@ class Vapid01(object):
         """Initialize VAPID with an optional private key.
 
         :param private_key: A private key object
-        :type private_key: ecdsa.SigningKey
+        :type private_key: ec.EllipticCurvePrivateKey
 
         """
         self.private_key = private_key

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,1 @@
-ecdsa==0.13
 cryptography>=1.8.2


### PR DESCRIPTION
ecdsa was [removed](https://github.com/web-push-libs/vapid/pull/42) but it's still getting installed from the requirements.txt file