### PR TITLE
Fix cryptography v2.5 lib deprecation warnings

### DIFF
--- a/python/py_vapid/__init__.py
+++ b/python/py_vapid/__init__.py
@@ -67,10 +67,10 @@ class Vapid01(object):
 
     @classmethod
     def from_raw_public(cls, public_raw):
-        key = ec.EllipticCurvePublicNumbers.from_encoded_point(
+        key = ec.EllipticCurvePublicKey.from_encoded_point(
             curve=ec.SECP256R1(),
             data=b64urldecode(public_raw)
-        ).public_key(default_backend())
+        )
         ss = cls()
         ss._public_key = key
         return ss
@@ -258,13 +258,13 @@ class Vapid01(object):
         cclaims = copy.deepcopy(claims)
         if not cclaims.get('exp'):
             cclaims['exp'] = str(int(time.time()) + 86400)
-        if not re.match("mailto:.+@.+\..+",
+        if not re.match(r'mailto:.+@.+\..+',
                         cclaims.get('sub', ''),
                         re.IGNORECASE):
             raise VapidException(
                 "Missing 'sub' from claims. "
                 "'sub' is your admin email as a mailto: link.")
-        if not re.match("^https?:\/\/[^\/\.:]+\.[^\/:]+(:\d+)?$",
+        if not re.match(r"^https?://[^/.:]+\.[^/:]+(:\d+)?$",
                         cclaims.get("aud", ""),
                         re.IGNORECASE):
             raise VapidException(
@@ -289,7 +289,10 @@ class Vapid01(object):
         sig = sign(self._base_sign(claims), self.private_key)
         pkey = 'p256ecdsa='
         pkey += b64urlencode(
-            self.public_key.public_numbers().encode_point())
+            self.public_key.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint
+            ))
         if crypto_key:
             crypto_key = crypto_key + ';' + pkey
         else:
@@ -309,7 +312,10 @@ class Vapid02(Vapid01):
 
     def sign(self, claims, crypto_key=None):
         sig = sign(self._base_sign(claims), self.private_key)
-        pkey = self.public_key.public_numbers().encode_point()
+        pkey = self.public_key.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint
+            )
         return{
             "Authorization": "{schema} t={t},k={k}".format(
                 schema=self._schema,

--- a/python/py_vapid/jwt.py
+++ b/python/py_vapid/jwt.py
@@ -2,7 +2,6 @@ import binascii
 import json
 
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec, utils
 from cryptography.hazmat.primitives import hashes
 
@@ -47,10 +46,10 @@ def decode(token, key):
     try:
         sig_material, signature = extract_signature(token)
         dkey = b64urldecode(key.encode('utf8'))
-        pkey = ec.EllipticCurvePublicNumbers.from_encoded_point(
+        pkey = ec.EllipticCurvePublicKey.from_encoded_point(
             ec.SECP256R1(),
             dkey,
-        ).public_key(default_backend())
+        )
         pkey.verify(
             signature,
             sig_material,

--- a/python/py_vapid/main.py
+++ b/python/py_vapid/main.py
@@ -6,6 +6,8 @@ import argparse
 import os
 import json
 
+from cryptography.hazmat.primitives import serialization
+
 from py_vapid import Vapid01, Vapid02, b64urlencode
 
 
@@ -60,7 +62,10 @@ def main():
     claim_file = args.sign
     result = dict()
     if args.applicationServerKey:
-        raw_pub = vapid.public_key.public_numbers().encode_point()
+        raw_pub = vapid.public_key.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint
+            )
         print("Application Server Key = {}\n\n".format(
             b64urlencode(raw_pub)))
     if claim_file:

--- a/python/py_vapid/tests/test_vapid.py
+++ b/python/py_vapid/tests/test_vapid.py
@@ -4,6 +4,7 @@ import copy
 import os
 import json
 import unittest
+from cryptography.hazmat.primitives import serialization
 from nose.tools import eq_, ok_
 from mock import patch, Mock
 
@@ -137,7 +138,10 @@ class VapidTestCase(unittest.TestCase):
         eq_(result['Crypto-Key'],
             'id=previous;p256ecdsa=' + T_PUBLIC_RAW.decode('utf8'))
         pkey = binascii.b2a_base64(
-            v.public_key.public_numbers().encode_point()
+            v.public_key.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint
+            )
         ).decode('utf8').replace('+', '-').replace('/', '_').strip()
         items = decode(result['Authorization'].split(' ')[1], pkey)
         for k in claims:

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-cryptography>=1.8.2
+cryptography>=2.5

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 
 def read_from(file):


### PR DESCRIPTION
This MR fix two deprecation warnings with last cyptography library :
```
site-packages/py_vapid/__init__.py:292: CryptographyDeprecationWarning: encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.
  self.public_key.public_numbers().encode_point())
```
And

```
py_vapid/__init__.py:72: CryptographyDeprecationWarning: Support for unsafe construction of public numbers from encoded data will be removed in a future version. Please use EllipticCurvePublicKey.from_encoded_point
```