### PR TITLE
use Vapid02 for default Vapid

### DIFF
--- a/python/py_vapid/__init__.py
+++ b/python/py_vapid/__init__.py
@@ -345,4 +345,4 @@ class Vapid02(Vapid01):
         )
 
 
-Vapid = Vapid01
+Vapid = Vapid02


### PR DESCRIPTION
use `Vapid02` for default `Vapid`, I missed this when commenting on #75