### PR TITLE
relax 'aud' check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
 - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
 - "2.7"
 - "3.5"
+- "3.6"
+- "3.7"
 install:
 - cd python
 - pip install -r requirements.txt

--- a/python/py_vapid/__init__.py
+++ b/python/py_vapid/__init__.py
@@ -264,7 +264,7 @@ class Vapid01(object):
             raise VapidException(
                 "Missing 'sub' from claims. "
                 "'sub' is your admin email as a mailto: link.")
-        if not re.match(r"^https?://[^/.:]+\.[^/:]+(:\d+)?$",
+        if not re.match(r"^https?://[^/:]+(:\d+)?$",
                         cclaims.get("aud", ""),
                         re.IGNORECASE):
             raise VapidException(

--- a/python/py_vapid/tests/test_vapid.py
+++ b/python/py_vapid/tests/test_vapid.py
@@ -179,6 +179,17 @@ class VapidTestCase(unittest.TestCase):
         for k in claims:
             eq_(t_val[k], claims[k])
 
+    def test_sign_02_localhost(self):
+        v = Vapid02.from_file("/tmp/private")
+        claims = {"aud": "http://localhost:8000",
+                  "sub": "mailto:admin@example.com",
+                  "foo": "extra value"}
+        result = v.sign(claims, "id=previous")
+        auth = result['Authorization']
+        eq_(auth[:6], 'vapid ')
+        ok_(' t=' in auth)
+        ok_(',k=' in auth)
+
     def test_integration(self):
         # These values were taken from a test page. DO NOT ALTER!
         key = ("BDd3_hVL9fZi9Ybo2UUzA284WG5FZR30_95YeZJsiApwXKpNcF1rRPF3foI"


### PR DESCRIPTION
In unit tests I'm running a dummy server to mock the web push endpoint but running into problems with vapid being too strict about how the `aud` endpoint looks. 

This permits `http://localhost:1234` as the `aud` endpoint. This is no less secure since the current check accepts `127.0.0.1` which is equivalent.

Also test against modern python.