### PR TITLE
upd importKey api

### DIFF
--- a/js/vapid.js
+++ b/js/vapid.js
@@ -135,6 +135,15 @@ class VapidCore {
         };
 
         return webCrypto.importKey('jwk', jwk, 'ECDSA', true, ["verify"])
+            .catch(err => {
+                if (err instanceof TypeError && /namedCurve/.test(err.stack))
+                    return webCrypto.importKey('jwk', jwk, {
+                        name: "ECDSA",
+                        namedCurve: "P-256"
+                    }, true, ["verify"])
+                        .then(k => this._public_key = k)
+                throw err
+            })
             .then(k => this._public_key = k)
     }
 


### PR DESCRIPTION
I like the https://web-push-libs.github.io/vapid/js/ website but the headers check doesn't work nowadays unfortunately - it throws an error `namedCurve missing`. I think the crypto API has been updated since the website was published. 

![image](https://user-images.githubusercontent.com/60678477/79595881-4d8bd880-80e8-11ea-8715-231880ecae04.png)
