### PR TITLE
py_vapid: do not enforce dot in sub claim email host part

### DIFF
--- a/python/py_vapid/__init__.py
+++ b/python/py_vapid/__init__.py
@@ -259,7 +259,7 @@ class Vapid01(object):
         cclaims = copy.deepcopy(claims)
         if not cclaims.get('exp'):
             cclaims['exp'] = str(int(time.time()) + 86400)
-        if not re.match(r'mailto:.+@.+\..+',
+        if not re.match(r'mailto:.+@.+',
                         cclaims.get('sub', ''),
                         re.IGNORECASE):
             raise VapidException(


### PR DESCRIPTION
While developing our django application, we had `admin@localhost` configured as our site contact address, which was automatically used by our webpush lib. While testing, py_vapid errored complaining that the sub claim wasn't there, even though it was. `mailto:admin@localhost` wasn't considered as a valid sub claim. 
I propose not enforcing having a dot in the regex, so people don't have to get frustrated figuring that out like me.

Although I would understand if you would say that a `localhost` host shouldn't be considered valid in a sub claim. We mitigated by changing our default developing contact address.