### PR TITLE
bug: use better host validation for `sub`

### DIFF
--- a/python/py_vapid/main.py
+++ b/python/py_vapid/main.py
@@ -31,6 +31,8 @@ def main():
                         default=False, action="store_true")
     parser.add_argument('--json',  help="dump as json",
                         default=False, action="store_true")
+    parser.add_argumet('--no-strict', help='Do not be strict about "sub"',
+                        default=False, action="store_true")
     parser.add_argument('--applicationServerKey',
                         help="show applicationServerKey value",
                         default=False, action="store_true")
@@ -52,7 +54,7 @@ def main():
                 if answer == 'n':
                     print("Sorry, can't do much for you then.")
                     exit(1)
-        vapid = Vapid()
+        vapid = Vapid(conf=args)
         vapid.generate_keys()
         print("Generating private_key.pem")
         vapid.save_key('private_key.pem')


### PR DESCRIPTION
While far from perfect, this is a little better about checking the sorts
of values passed in the `sub` claim. It checks for ipv6 like as well as
localhost in mailto and https forms. (Yeah, you'll still need to supply
`https` since that's part of the RFC. Plus, letsEncrypt is a thing, so
there's that.)

I've also introduced a new option `--no-strict` which turns off
`sub` checks. It has to be present, but what the value is can be up to
you. I'll note that this kinda ruins what VAPID is supposed to be about.
The `sub` is there so that if there's a problem with your subscription,
Ops can reach out to you to help fix it rather than just straight up
block you.

Closes: #90