### PR TITLE
prefer newer unittest.mock from standard library

### DIFF
--- a/python/py_vapid/tests/test_vapid.py
+++ b/python/py_vapid/tests/test_vapid.py
@@ -5,7 +5,10 @@ import os
 import json
 import unittest
 from cryptography.hazmat.primitives import serialization
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 
 from py_vapid import Vapid01, Vapid02, VapidException, _check_sub
 from py_vapid.jwt import decode


### PR DESCRIPTION
Hi,

The good new is that VAPID enterred today in Debian.

The bad news is that we are trying to get rid of old Python 2.7-3.4 era `mock` backport.

Please consider this patch