### PR TITLE
Rust: Add 'Clone' to Key struct 

### DIFF
--- a/rust/vapid/src/lib.rs
+++ b/rust/vapid/src/lib.rs
@@ -50,6 +50,7 @@ mod error;
 ///
 /// Vapid Keys are always Prime256v1 EC keys.
 ///
+#[derive(Clone)]
 pub struct Key {
     key: EcKey<Private>,
 }


### PR DESCRIPTION
This can be helpful to prevent need of repeated reading from .pem file.